### PR TITLE
Update runtime to 5.15-21.08

### DIFF
--- a/io.github.gillesdegottex.FMIT.json
+++ b/io.github.gillesdegottex.FMIT.json
@@ -3,7 +3,7 @@
     "branch" : "stable",
     "runtime" : "org.kde.Platform",
     "sdk" : "org.kde.Sdk",
-    "runtime-version" : "5.15",
+    "runtime-version" : "5.15-21.08",
     "command" : "fmit",
     "rename-icon" : "fmit",
     "rename-desktop-file" : "fmit.desktop",


### PR DESCRIPTION
The 5.15 version of the KDE Runtime is based on the 20.08 version of the Freedesktop Runtime and will stay as-is to keep compatibility.
The 5.15-21.08 version of the KDE Runtime is based on the 21.08 Freedesktop one. The Qt/KDE Libraries are mostyl similar between the two runtimes.

This change is mostly maintenance to keep the base runtime updated.